### PR TITLE
Refocus OpenShelf README on product use

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,108 +1,65 @@
 <div align="center">
 
-# 📚 OpenShelf
+# OpenShelf
 
-**Enumerate and batch-export the ebooks you purchased on Google Play Books**
+**Batch-export the Google Play Books files you are legitimately allowed to export, and keep them organized on your own computer.**
 
-DRM-free books → EPUB / PDF · DRM books → the official `.acsm` for Adobe Digital Editions · un-exportable ones are only recorded
+DRM-free books → EPUB / PDF · protected books → official `.acsm` for Adobe Digital Editions · unavailable exports → record only
 
 [**English**](README.en.md) ｜ [繁體中文](README.md)
 
+[![Release](https://img.shields.io/github/v/release/SanHsien/openshelf?sort=semver)](https://github.com/SanHsien/openshelf/releases/latest)
 [![CI](https://github.com/SanHsien/openshelf/actions/workflows/ci.yml/badge.svg)](https://github.com/SanHsien/openshelf/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![Playwright](https://img.shields.io/badge/Login-Playwright-2EAD33?logo=playwright&logoColor=white)](https://playwright.dev/python/)
-[![Download](https://img.shields.io/badge/Transport-HTTP%20(httpx)-blue)](https://www.python-httpx.org/)
-[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)]()
-[![Status](https://img.shields.io/badge/Status-stable%20v1.0.4-brightgreen)]()
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](#platform-support)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
+[Download latest release](https://github.com/SanHsien/openshelf/releases/latest) · [Run from source](#run-from-source) · [Development and tests](#development-and-tests)
 
 </div>
 
----
-
-> [!IMPORTANT]
-> **This tool only does lawful exporting — it never breaks any protection.**
-> An `.acsm` is just a fulfillment token; it does not contain the book's content. Adobe Digital Editions (ADE) is what downloads the book, binds it to your Adobe ID, and manages the DRM — the book stays encrypted throughout. OpenShelf does only two things with an `.acsm`: **download it** and **store it as-is**.
-> **No ACSM parsing, no fulfilling outside ADE, no key extraction, no protection removal.** If what you want is "DRM stripping", this tool does not do it.
-
-## ✨ Features
-
-- 🔎 **One-click enumeration** of your whole Google Play Books library, auto-classifying each book's export status.
-- 📥 **Three-way routing**: DRM-free → EPUB/PDF, DRM → official `.acsm`, un-exportable → record only.
-- 🔐 **Never touches your credentials**: you sign in once in a real browser; the program only reuses the saved session.
-- 🌐 **HTTP-first**: enumeration and downloads go through `httpx` backend endpoints, not fragile page DOM.
-- 🧾 **manifest as the single source of truth**: resume, skip already-downloaded, produce reports.
-- ♻️ **Re-runnable**: interrupt it and run again — it picks up where it left off instead of re-downloading.
-- 🖥️ **Desktop GUI** with search, covers, a download queue with ETA, retry-failed, CSV/HTML export, and **English/Chinese UI**.
-
-## 🖼️ Screenshot
-
 ![OpenShelf main window](docs/screenshots/main-window.png)
 
-> The screenshot uses demo data only. It does not include a real Google account, library, or downloaded content.
+OpenShelf is a local Google Play Books export tool. You sign in once in a real browser; the app then enumerates your own library, determines what Google allows to be exported, and tracks the result in a resumable manifest.
 
-## 📑 Table of contents
+The goal is not to break ebook protection. The goal is to turn Google's existing per-book export options into a repeatable, inspectable batch workflow.
 
-- [Boundary & disclaimer](#-boundary--disclaimer)
-- [Screenshot](#️-screenshot)
-- [How it works](#-how-it-works)
-- [Quick start](#-quick-start)
-- [Commands](#-commands)
-- [Reading `.acsm` with ADE](#-reading-acsm-with-ade)
-- [Configuration](#️-configuration)
-- [Output & manifest](#-output--manifest)
-- [Project layout](#️-project-layout)
-- [Tests](#-tests)
-- [Roadmap](#️-roadmap)
-- [FAQ](#-faq)
-- [Packaging to .exe](#-packaging-to-exe-pyinstaller)
-- [Limitations & notes](#️-limitations--notes)
-- [Third-party tooling background](#-third-party-tooling-background)
-- [License & copyright](#-license--copyright)
+## What it does
 
-## 🧱 Boundary & disclaimer
-
-| Does ✅ | Does not ❌ |
+| Book status | What OpenShelf does |
 |---|---|
-| Download the official export files of books you own | Parse `.acsm` content |
-| Save DRM-free books as EPUB/PDF | Fulfill outside ADE / extract the EPUB |
-| Download the `.acsm` and store it as-is for ADE | Extract Adobe ADEPT keys |
-| Classify, record, and skip un-exportable books | Remove or break any DRM/protection |
+| Google offers EPUB / PDF | Downloads the official DRM-free file |
+| Google only offers ACSM | Downloads the official `.acsm` and hands it to Adobe Digital Editions |
+| Google offers no export | Records `no_export`; does not bypass the restriction |
+| Download or endpoint failure | Records `failed` so it can be retried later |
 
-> Automating a signed-in Google service may conflict with its Terms of Service; assess and accept that risk yourself. This tool is only for exporting books **you lawfully own**.
+Highlights:
 
-## 🧭 How it works
+- **Local-first**: no OpenShelf cloud account and no hosted copy of your library or files.
+- **No password handling**: you complete sign-in yourself in a real browser; the program only reuses the resulting session.
+- **HTTP-first after login**: library enumeration and downloads use backend requests instead of fragile DOM automation.
+- **Resumable**: `manifest.json` is the local state record, so interrupted runs do not have to start over.
+- **GUI + CLI**: a desktop app for normal use and an `openshelf` command for automation and diagnostics.
+- **Reports and handoff**: TXT / CSV / HTML reports plus separate EPUB/PDF, ACSM, and Calibre handoff flows.
 
-OpenShelf is **HTTP-first**: the browser is used **only for a one-time sign-in** (Google blocks scripted credential login, so manual sign-in is the most robust). After the session is saved locally, **enumeration and downloads call the same Play Books web-version backend endpoints via `httpx`**, not page DOM/button selectors — the DOM is what breaks first when a site changes.
+## Download and use
 
-```mermaid
-flowchart LR
-    A[openshelf login<br/>sign in once in a browser] -->|storage_state.json| B[openshelf scan<br/>enumerate over HTTP]
-    B -->|manifest.json| C[openshelf export<br/>download book by book]
-    C --> D{classify}
-    D -->|drm_free| E[EPUB / PDF]
-    D -->|acsm| F[.acsm → hand off to ADE]
-    D -->|no_export| G[record only]
-    C --> H[openshelf status<br/>stats and report]
-```
+### Windows: use a release build
 
-**Classification rules:**
+Go to [Latest Release](https://github.com/SanHsien/openshelf/releases/latest). The stable release provides a Windows installer and portable packages, with SHA-256 checksum files for major artifacts.
 
-| Library offers | Category | Action |
-|---|---|---|
-| EPUB / PDF | `drm_free` | Download the file, verify extension + size |
-| ACSM only | `acsm` | Download the `.acsm`, store as-is |
-| Nothing | `no_export` | Record only |
-| Error | `failed` | Record the error, retry next time |
+Typical first run:
 
-After downloading, files are verified by extension and size: an `.acsm` is only a few KB of XML, while EPUB/PDF are clearly larger. A mismatch is marked `failed` for retry.
+1. **Sign in**: open the browser and sign in to your own Google account.
+2. **Scan**: enumerate your Google Play Books library and build the local manifest.
+3. **Export**: download permitted EPUB/PDF files or official `.acsm` files.
+4. **Review**: search the result, retry failures, or export reports.
 
-> [!NOTE]
-> **Endpoint isolation**: Play Books has no official "download a purchased book" API. Library enumeration uses the private `SyncUserLibrary` gRPC-Web RPC (authenticated with SAPISIDHASH); download URLs are embedded in the response — a direct link for DRM-free books, an `.acsm` fulfillment token for DRM books. This layer is isolated in `openshelf/playbooks.py`, so a Google backend change usually means editing that one file.
+> Current Windows binaries are not Authenticode-signed, so SmartScreen may show an unknown-publisher warning. Download only from this repository's Releases and verify the SHA-256 file when appropriate.
 
-## 🚀 Quick start
+### Run from source
 
-**Requirements**: Python 3.11+, and a desktop GUI environment for the first sign-in.
+Requires Python 3.11+.
 
 ```bash
 git clone https://github.com/SanHsien/openshelf.git
@@ -110,316 +67,129 @@ cd openshelf
 pip install -e .
 ```
 
-> The first sign-in prefers your local Chrome / Edge. Only if you need to fall back to Playwright's bundled Chromium do you run `playwright install chromium`.
+First use:
 
 ```bash
-openshelf login     # 1) open a browser, sign in once
-openshelf scan      # 2) enumerate the library, build the manifest
-openshelf export    # 3) download the exportable books
-openshelf status    # 4) see the stats
+openshelf login
+openshelf scan
+openshelf export
+openshelf status
 ```
 
-## 🧩 Commands
-
-| Command | Description | Common options |
-|---|---|---|
-| `openshelf login` | Open a browser to sign in once and save the session | `--headless` |
-| `openshelf scan` | Enumerate and classify the library over HTTP, write the manifest | |
-| `openshelf export` | Download exportable books (EPUB/PDF or `.acsm`) | `--format pdf`, `--skip-acsm`, `--only`, `--limit`, `--refresh-acsm`, `--force-refresh-acsm`, `--skip-failed` |
-| `openshelf status` | Show manifest stats and refresh the download report | |
-| `openshelf report` | Write reports to the output folder (missing-books list / CSV / HTML) | `--format txt\|csv\|html\|all` |
-| `openshelf doctor` | Endpoint health check: confirm Google's backend response shape still matches | |
-| `openshelf acsm-open` | Batch-open downloaded `.acsm` with the default app | `--dry-run`, `--limit`, `--include-opened` |
-| `openshelf acsm-report` | Write the ACSM handoff report without opening anything | |
-| `openshelf ebook-open` | Batch-open downloaded DRM-free EPUB/PDF | `--target ade`, `--target default`, `--dry-run` |
-| `openshelf ebook-report` | Write the EPUB/PDF handoff report without opening anything | `--target ade`, `--target default` |
-| `openshelf calibre-import` | Import downloaded DRM-free EPUB/PDF into a Calibre library | `--library-path`, `--dry-run` |
-| `openshelf calibre-report` | Write the Calibre handoff report without importing | |
-| `openshelf ui` | Open the desktop GUI (needs `pip install -e '.[gui]'`) | |
+For the desktop UI:
 
 ```bash
-openshelf export --format pdf            # prefer PDF for DRM-free books (falls back to EPUB)
-openshelf export --skip-acsm             # DRM-free only; DRM books are recorded but no .acsm fetched
-openshelf export --only acsm --limit 1   # smoke test: fetch the .acsm of a single DRM book
-openshelf export --force-refresh-acsm --limit 25  # when ADE shows E_ADEPT_REQUEST_EXPIRED, re-fetch in batches
-openshelf export --skip-failed           # stop retrying known failures (e.g. Google refuses the file)
-openshelf acsm-open --dry-run            # list the .acsm that can be handed to ADE / the default app
-openshelf acsm-open --limit 25           # open downloaded .acsm in batches
-openshelf acsm-open --limit 25 --include-opened  # resend a previously sent batch after ADE failed
-openshelf ebook-open --target ade --dry-run  # list the DRM-free EPUB/PDF that can go to ADE
-openshelf ebook-open --target ade            # batch-open DRM-free EPUB/PDF with ADE
-openshelf calibre-import --dry-run       # list what would be imported into Calibre
-openshelf calibre-import                 # import downloaded DRM-free EPUB/PDF into Calibre
-openshelf --config path/to/config.toml status   # use a specific config file
+pip install -e ".[gui]"
+openshelf ui
 ```
 
-> Calibre handoff only processes `drm_free` EPUB/PDF that exist on disk; `.acsm` is never imported into Calibre and still needs ADE.
+Login prefers a locally installed Chrome or Edge. Playwright's bundled Chromium is only needed as a fallback.
 
-## 📖 Reading `.acsm` with ADE
+## Workflow
 
-A DRM book downloads as an `.acsm`, **not the book itself**. To read it (done on your own computer; the tool is not involved):
-
-1. Install **Adobe Digital Editions 4.5** and authorize the machine with your Adobe ID.
-2. Double-click the `.acsm` in `output/`, or run `openshelf acsm-open` to hand them off to the default app.
-3. Read inside ADE. The book is protected by Adobe DRM and only opens on authorized ADE/devices.
-
-If ADE shows `E_ADEPT_REQUEST_EXPIRED`, the `.acsm` fulfillment token has expired. Re-download the official `.acsm` first: in the desktop app, enable **Force re-fetch .acsm** and click Download; in the CLI, run `openshelf export --force-refresh-acsm`, then open the new `.acsm` with ADE.
-
-Do not hand a large `.acsm` library to ADE all at once. ADE queues them, and later tokens may expire while waiting. Use batches instead:
-
-1. Desktop app: set **Batch** to 20-30, enable **Force re-fetch .acsm**, click Download, then click Open ACSM. Wait for ADE to finish the batch and repeat.
-2. CLI: run `openshelf export --force-refresh-acsm --limit 25`, then `openshelf acsm-open --limit 25`. Wait for ADE to finish the batch and repeat.
-3. OpenShelf only records "handed off to ADE / the default app"; it cannot know whether ADE successfully imported the book. If ADE fails immediately, enable **Include sent** in the desktop app or pass `--include-opened` in the CLI to resend that batch.
-
-`.acsm` re-fetch options:
-
-| Option | CLI | Use case |
-|---|---|---|
-| **Re-fetch stale .acsm** | `openshelf export --refresh-acsm` | Re-download only `.acsm` files that OpenShelf considers stale based on download time + `acsm_valid_days`. Use this for routine cleanup. |
-| **Force re-fetch .acsm** | `openshelf export --force-refresh-acsm` | Ignore validity days and re-download already-downloaded `.acsm` files that have not yet been handed off to ADE. Use this when ADE shows `E_ADEPT_REQUEST_EXPIRED`; pair it with `--limit 25` for batches. |
-
-OpenShelf does not parse `.acsm`, so it does not know Adobe's actual fulfillment expiry; `acsm_valid_days` is only a reminder proxy.
-
-## ⚙️ Configuration
-
-Settings live in `config.toml` at the project root. Anything not listed falls back to the built-in default.
-
-| Key | Default | Description |
-|---|---|---|
-| `output_dir` | `"output"` | Where ebooks and `.acsm` are stored |
-| `profile_dir` | `".profile"` | Playwright persistent sign-in profile (do not commit) |
-| `storage_state` | `"storage_state.json"` | Session snapshot with cookies (do not commit) |
-| `prefer_format` | `"epub"` | Preferred format for DRM-free books, `epub` or `pdf` |
-| `include_acsm` | `true` | Whether to fetch `.acsm` for DRM books |
-| `throttle_seconds` | `2.0` | Delay between books (throttling) |
-| `download_timeout` | `120` | Per-book download timeout, in seconds |
-| `download_retries` | `3` | Download retry count (network errors / 5xx only) |
-| `acsm_valid_days` | `7` | Days an `.acsm` is treated as valid (a proxy based on **download time**) |
-| `calibredb_path` | `""` | Path to the Calibre CLI; empty means auto-detect `calibredb` and common install locations |
-| `calibre_library` | `""` | Calibre library path; empty means use Calibre's default library |
-| `ade_path` | `""` | Path to the ADE executable; empty means look in common install locations, then fall back to the default app |
-
-## 📂 Output & manifest
-
-- Ebooks and `.acsm` → `output/` (configurable in `config.toml`).
-- `output/manifest.json` → per book: `volume_id`, title, author, publisher, category (`drm_free` / `acsm` / `no_export` / `failed`), download path and time. **Resume and skip are decided from this file** (machine-readable).
-- `output/下載報表.txt` → the **human-readable report**, refreshed after scan/export/status, highlighting **missing books** (failed, no-export) and stale `.acsm`. Regenerate any time with `openshelf report`.
-- `output/ACSM交接報表.txt` → the `.acsm` that can be opened with ADE / the default app, plus missing files.
-- `output/EPUB-PDF交接報表.txt` → the DRM-free EPUB/PDF that can be handed to ADE / the default app, plus missing files.
-- `output/Calibre交接報表.txt` → the DRM-free EPUB/PDF that can be imported into Calibre, missing files, and the `.acsm` that are deliberately not imported.
-- `output/書庫清單.csv` / `output/書庫報表.html` → spreadsheet- and browser-friendly exports (`openshelf report`).
-
-> `output/`, `.profile/`, and `storage_state.json` are git-ignored and never committed.
-
-## 🗂️ Project layout
-
-```
-openshelf/
-  cli.py        command entry point (login / scan / export / status / report / doctor / handoffs / ui)
-  config.py     read config.toml + defaults
-  browser.py    one-time Playwright sign-in, save storage_state (cookies)
-  session.py    load storage_state into an authenticated httpx client
-  playbooks.py  Play Books backend endpoints: enumerate, export options, resolve download URLs
-  classify.py   drm_free / acsm / no_export decision
-  export.py     HTTP download (EPUB/PDF and .acsm), naming, verification
-  manifest.py   read/write the manifest (resume, skip, reports)
-  acsm.py       ACSM handoff (batch-open .acsm with the default app)
-  reader.py     EPUB/PDF handoff (DRM-free files to ADE or the default app)
-  calibre.py    Calibre handoff (DRM-free EPUB/PDF only)
-  service.py    scan / export orchestration shared by CLI and GUI; txt / csv / html reports
-  logsetup.py   structured logging (output/openshelf.log)
-  update.py     check GitHub Releases for a newer version (comparison only, never self-overwrites)
-  ui/           desktop GUI (PySide6); i18n.py holds the English/Chinese strings
-app.py          desktop entry point (for packaging)
-assets/         app icons (openshelf.ico / .png; shared by the exe and the window)
-openshelf.spec  PyInstaller build spec (one file, windowed, embedded icon)
-build_exe.py    convenience script to build the executable locally
-tools/          maintenance scripts (README demo screenshot, dependency freshness, Dependabot classification)
-tests/          unit and integration tests (parsing, classification, naming, manifest, config, reports, ACSM staleness, i18n, dependency automation)
-installer/      Inno Setup installer script (openshelf.iss)
-docs/           screenshot workflow, third-party tooling background, per-version release notes
-.github/        CI, Release, Dependabot and dependency-freshness workflows; issue / PR templates
-config.toml     configuration file
-pyproject.toml  package metadata and dependencies
+```mermaid
+flowchart LR
+    A[Manual browser sign-in] --> B[scan library]
+    B --> C[manifest.json]
+    C --> D[export]
+    D --> E[EPUB / PDF]
+    D --> F[official .acsm]
+    D --> G[no_export / failed record]
+    C --> H[status / report]
 ```
 
-## 🧪 Tests
+Google Play Books does not provide a public "download my purchased books" API. OpenShelf isolates the current library endpoint integration in `openshelf/playbooks.py`, so a Google-side change is primarily an adapter-maintenance problem rather than a GUI rewrite.
 
-No network, no browser, and no saved session required. Coverage includes library-response parsing, three-way classification, filename de-duplication and verification, manifest, config, reports, ACSM staleness, the English/Chinese UI strings, plus mock-`httpx` integration tests for pagination and classification and the dependency-maintenance tooling:
+## Common commands
+
+| Command | Purpose |
+|---|---|
+| `openshelf login` | Sign in manually and save session state |
+| `openshelf scan` | Enumerate the library and update the manifest |
+| `openshelf export` | Download available EPUB/PDF or `.acsm` files |
+| `openshelf status` | Show current counts and state |
+| `openshelf report` | Produce TXT / CSV / HTML reports |
+| `openshelf doctor` | Check whether the Google endpoint still matches expectations |
+| `openshelf acsm-open` | Hand downloaded `.acsm` files to the default app / ADE |
+| `openshelf ebook-open` | Open downloaded DRM-free EPUB/PDF files |
+| `openshelf calibre-import` | Import DRM-free EPUB/PDF files into Calibre |
+| `openshelf ui` | Launch the desktop UI |
+
+See complete options with:
+
+```bash
+openshelf --help
+openshelf export --help
+```
+
+Common examples:
+
+```bash
+openshelf export --format pdf
+openshelf export --skip-acsm
+openshelf export --only acsm --limit 10
+openshelf export --force-refresh-acsm
+openshelf calibre-import --dry-run
+```
+
+## `.acsm` and the DRM boundary
+
+> [!IMPORTANT]
+> **OpenShelf does not break DRM.**
+
+An `.acsm` file is a fulfillment token used by Adobe Digital Editions; it is not the ebook itself. OpenShelf only **downloads** that official token and **stores or hands it off unchanged**.
+
+OpenShelf does **not**:
+
+- parse ACSM content to fulfill books outside ADE;
+- extract Adobe ADEPT or other keys;
+- decrypt, strip, or remove DRM;
+- obtain book files that Google does not offer for export.
+
+If ADE reports `E_ADEPT_REQUEST_EXPIRED`, request a fresh official `.acsm`:
+
+```bash
+openshelf export --force-refresh-acsm
+```
+
+Background and third-party-tool boundaries are documented in [`docs/third-party-ebook-tooling.md`](docs/third-party-ebook-tooling.md).
+
+## Platform support
+
+| Platform | Status |
+|---|---|
+| Windows 10/11 x64 | **Primary validated platform**; installer and portable Releases are provided |
+| macOS | CI builds an `.app`; full real-device validation is not currently claimed |
+| Linux x64 | CI builds an executable; a desktop environment is needed for sign-in; full real-device validation is not currently claimed |
+
+The cross-platform core is Python. The GUI uses PySide6, sign-in uses a browser / Playwright, and downloads use `httpx`.
+
+## Data and privacy
+
+OpenShelf has no hosted backend. Session state, the manifest, downloaded files, and logs remain on your computer.
+
+Automating an authenticated Google service may still be subject to Google's terms. OpenShelf is intended only for books you legitimately own and that the service itself permits you to export.
+
+## Development and tests
+
+After installing the project:
 
 ```bash
 python -m unittest discover -s tests
 ```
 
-CI runs the same suite on Python 3.11 / 3.12 / 3.13; all must pass.
+GitHub Actions runs CI tests, and the release workflow builds distribution artifacts. Version information should stay aligned between `pyproject.toml` and release tags.
 
-The README main-window screenshot is generated from fixed demo data, never a real library:
+Maintenance references:
 
-```bash
-python tools/generate_readme_screenshot.py
-```
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — development and contribution workflow
+- [`REPO_REVIEW.md`](REPO_REVIEW.md) — repository review and improvement notes
+- [`docs/release-notes/`](docs/release-notes/) — per-release notes
+- [`docs/screenshot-workflow.md`](docs/screenshot-workflow.md) — deterministic README screenshot workflow
+- [`NOTICE.md`](NOTICE.md) — attribution and notices
 
-Details in [docs/screenshot-workflow.md](docs/screenshot-workflow.md) (written in Chinese).
+## License
 
-## 🛣️ Roadmap
+[Apache License 2.0](LICENSE). Copyright © 2026 SanHsien.
 
-### ✅ Completed (M1–M11, currently v1.0.4)
-
-- [x] **M1**: one-time browser sign-in + saved session (`browser.py` / `session.py`)
-- [x] **M2**: endpoint discovery — SyncUserLibrary RPC + SAPISIDHASH auth, wired into `playbooks.py`
-- [x] **M3**: three-way classification + `scan` writing the manifest
-- [x] **M4**: HTTP download (direct EPUB/PDF, `.acsm` stored as-is) + naming + verification + resume + `status`
-- [x] **M5**: throttling, download retry with backoff, friendly expired-session message, filename de-duplication for same-titled books, header verification, unit tests
-- [x] **M6**: desktop UI shell (PySide6): book table, scan/download/stop, log, status bar (worker thread + signals)
-- [x] **M7**: PyInstaller single-file packaging (`app.py` / `openshelf.spec` / `build_exe.py`; frozen paths and bundled Chromium handled)
-- [x] **M8**: handoffs and public readiness — `.acsm` / EPUB·PDF / Calibre handoffs and reports, human-readable download report, `.acsm` staleness reminder, automatic library pagination, app icon and About box, Apache-2.0 license, GitHub Actions CI and contribution templates
-- [x] **M9**: desktop UX (v0.4) — table search and remembered column widths, cover thumbnails, download queue with ETA, retry failed, CSV/HTML reports, English UI (i18n) and a bilingual README
-- [x] **M10**: packaging and releases (v0.5) — CI builds the Windows exe and publishes a Release (lean / portable / installer, all with SHA256), update check, first-run tour, code-signing notes
-- [x] **M11**: stable (v1.0) — endpoint self-diagnosis (`openshelf doctor`), mock-httpx integration tests (pagination / classification), structured logging (`output/openshelf.log`), cross-platform CI builds (macOS `.app` / Linux executable; non-Windows builds not yet tested on real hardware)
-
-> Current state: **stable (v1.0.4)** — `login → scan → export` works end to end; three-way routing, download retries, three handoffs with reports, desktop GUI (search / covers / queue / bilingual UI / first-run tour / update check), batched ACSM handoff, endpoint self-diagnosis and structured logging, and Windows/macOS/Linux CI publishing. Windows release artifacts have been smoke-tested locally; macOS and Linux artifacts are CI-built only and have not been tested on those platforms. Test coverage spans parsing, classification, reports, ACSM staleness, i18n and the dependency tooling — see the CI run for the current count.
-
-### 🗺️ Planned
-
-> Everything below stays inside the project boundary. DRM circumvention, decryption, stripping, ACSM parsing, fulfilling outside ADE and key extraction will **never** be added (see "Never" below).
-
-```mermaid
-timeline
-    title OpenShelf roadmap
-    v0.4 Desktop UX : search and multi-column sort : cover thumbnails : download queue and progress detail : English UI (i18n)
-    v0.5 Packaging and releases : GitHub Actions builds the Windows exe : portable bundle with Chromium : installer with shortcut/icon : update check
-    v1.0 Stable : endpoint self-diagnosis : integration tests (mock httpx) : structured logging : cross-platform packaging (macOS/Linux untested on real hardware)
-```
-
-**v0.4 — Desktop UX** ✅ done
-- [x] Table search box, sorting, remembered column widths
-- [x] Cover thumbnails (from library metadata; no extra content fetched)
-- [x] Download queue: current title, estimated time remaining, inline retry for failures
-- [x] CSV / HTML report export
-- [x] English UI (i18n) and a bilingual README
-
-**v0.5 — Packaging and releases** ✅ done
-- [x] **CI builds the Windows `.exe`** and publishes to GitHub Releases (tag-triggered, with SHA256)
-- [x] **Portable bundle**: ships `ms-playwright/` Chromium inside `dist/` so users can unzip and run without `playwright install`
-- [x] **Installer** (Inno Setup): Start-menu shortcut, desktop icon, uninstaller
-- [x] **Update check**: compares against the latest GitHub Release and prompts (never self-overwrites)
-- [x] Code-signing notes to reduce Windows SmartScreen warnings
-- [x] First-run wizard: sign in → scan → download
-
-**v1.0 — Stable** ✅ done
-- [x] Endpoint health check / self-diagnosis (`openshelf doctor`): warns when Google's backend changes, centralized in `playbooks.py`
-- [x] Integration tests (mock `httpx` responses) covering pagination, de-duplication, stop conditions and every category
-- [x] Structured logging to file (`output/openshelf.log`) to make problem reports easier
-- [x] Cross-platform packaging: CI produces `OpenShelf.app` on macOS and an executable on Linux (polished `.dmg` / AppImage packaging is optional future work); non-Windows builds are not yet tested on real hardware
-
-### 🚫 Never
-
-- DRM circumvention, decryption, stripping.
-- Parsing `.acsm` content, fulfilling outside ADE, extracting Adobe ADEPT keys.
-- Removing or breaking any ebook protection, or integrating third-party tools for that purpose.
-
-> Issues and PRs heading in those directions will be declined. Background in [`docs/third-party-ebook-tooling.md`](docs/third-party-ebook-tooling.md) (written in Chinese).
-
-## ❓ FAQ
-
-<details>
-<summary><b>Why does sign-in need a browser? Can't it just call an API?</b></summary>
-
-Google aggressively blocks scripted credential login (CAPTCHA, 2FA, security blocks). Hand-rolling it is both fragile and a good way to get your account flagged. Signing in once yourself in a real browser and reusing the session is the most robust and the safest option. The program never handles your credentials.
-</details>
-
-<details>
-<summary><b>Will OpenShelf strip DRM for me?</b></summary>
-
-No, and it should not. DRM books only ever download the official `.acsm` for ADE, and the book stays encrypted throughout. This tool does not parse ACSM, extract keys, or remove protection.
-</details>
-
-<details>
-<summary><b>Why are some books classified as <code>no_export</code>?</b></summary>
-
-Not every book and not every region offers an export. Plenty of books can only be read inside the Play Books app; those have no downloadable file and are recorded as `no_export`.
-</details>
-
-<details>
-<summary><b>What happens if I download an <code>.acsm</code> and never open it in ADE?</b></summary>
-
-An `.acsm` generally has a fulfillment deadline and device-authorization limits, so it needs to be fulfilled in ADE reasonably soon; waiting too long or switching machines can invalidate it. That is decided by Adobe and the publisher, not by this tool.
-
-If ADE shows `E_ADEPT_REQUEST_EXPIRED`, the token has expired. Re-fetch the official `.acsm`: enable **Force re-fetch .acsm** in the desktop app, or run `openshelf export --force-refresh-acsm`.
-</details>
-
-<details>
-<summary><b>Will a Google change break it?</b></summary>
-
-It might. That is true of every tool built on Google's non-public interfaces. OpenShelf keeps the volatile endpoints in `playbooks.py`, so a change usually means editing that one file.
-</details>
-
-## 📦 Packaging to .exe (PyInstaller)
-
-> [!TIP]
-> **Automated release (recommended)**: push a `v*` tag (e.g. `git tag v1.0.4 && git push origin v1.0.4`) and GitHub Actions builds on Windows and publishes to **Releases** with three bundles:
-> - **Lean** `OpenShelf-<version>-windows-x64.zip` (exe only; sign-in uses your local Chrome/Edge)
-> - **Portable** `OpenShelf-<version>-windows-x64-portable.zip` (exe + bundled Chromium, unzip and run)
-> - **Installer** `OpenShelf-<version>-setup.exe` (Start-menu shortcut, optional desktop shortcut, uninstaller)
->
-> All ship with a `.sha256` checksum. See [`.github/workflows/release.yml`](.github/workflows/release.yml) and [`installer/openshelf.iss`](installer/openshelf.iss).
->
-> **Release notes**: before tagging, write the notes for that version to `docs/release-notes/<tag>.md` (e.g. `docs/release-notes/v1.0.4.md`). The workflow prefers that hand-written file and only falls back to `--generate-notes` when it is missing. Also confirm the version in `pyproject.toml` and `openshelf/__init__.py` matches the tag.
-
-> [!NOTE]
-> **About Windows SmartScreen**: an unsigned exe may be blocked on first run (choose "More info → Run anyway"). Removing the warning requires your own **code-signing certificate** (OV/EV), applied to `OpenShelf.exe` and the installer with `signtool sign /fd SHA256 /tr <timestamp server> /td SHA256 ...` after packaging. This project ships no certificate; if you need one, inject it into CI as a secret and add a signing step.
-
-> [!IMPORTANT]
-> PyInstaller **is not a cross-compiler**: producing a Windows `.exe` requires **building on Windows**; building on macOS/Linux yields that platform's executable. Every non-Windows CI artifact remains untested on real hardware.
-
-Manually, on the target OS (Windows if you want the `.exe`):
-
-```bash
-pip install -e ".[gui,build]"
-python build_exe.py              # equivalent to pyinstaller openshelf.spec --noconfirm
-```
-
-Artifacts land in `dist/` (single file, windowed, no console). The executable creates `output/`, `.profile/` and `storage_state.json` next to itself, not in system directories.
-
-### How Chromium is bundled (important)
-
-Sign-in prefers your local Chrome / Edge; a Chromium binary is only needed when falling back to Playwright's bundled browser. Chromium is **not** packed into the exe (browser binaries are large and independent of pip packages). `app.py` points `PLAYWRIGHT_BROWSERS_PATH` at an `ms-playwright/` folder **next to the exe**. If you want the bundled-Chromium fallback, pick one:
-
-1. **Ship it with the exe (recommended for distribution)**: run `playwright install chromium` before packaging, then copy the `chromium-*` folder from your local Playwright browser cache into `dist/ms-playwright/` and distribute them together.
-2. **Install on the user's machine**: run `playwright install chromium` once there and place the browser in `ms-playwright/` next to the exe (or set `PLAYWRIGHT_BROWSERS_PATH` to the same location).
-
-> Downloading (`httpx`) and enumeration need no browser at all; Chromium is only used by `login`.
-
-## ⚠️ Limitations & notes
-
-- DRM books only download the official `.acsm` for ADE; **no ACSM parsing, no key extraction, no protection removal**.
-- **`.acsm` validity**: an `.acsm` has a fulfillment deadline and device-authorization limits, so **download in batches and open them in ADE promptly**. OpenShelf uses "**the time we downloaded the `.acsm`** + `acsm_valid_days`" as a staleness proxy: stale entries are flagged by `status` and can be re-fetched with `openshelf export --refresh-acsm`.
-  > ⚠️ The tool **does not read the real expiry embedded in the `.acsm`** (that would require parsing ACSM content, which crosses the project boundary). The staleness above is only a reminder estimated from download time, not Adobe's actual expiry.
-- **Same-titled books**: when title + author collide, filenames are distinguished by "publication year · publisher"; if those match too, the `volume_id` is appended so files never overwrite each other.
-- **Library pagination**: enumeration pages automatically until the library is complete (following the reported total and cursor); the page size cap is 400 books.
-- Not every book or region offers an export; those are recorded as `no_export`.
-- Automating a signed-in Google service may conflict with its Terms of Service — assess that yourself.
-- When Google's library backend changes, the endpoints in `playbooks.py` need updating.
-
-## 🧰 Third-party tooling background
-
-Notes on ADE, Calibre, Epubor-style tools and where OpenShelf draws the line are collected in [`docs/third-party-ebook-tooling.md`](docs/third-party-ebook-tooling.md) (written in Chinese).
-
-## 📝 License & copyright
-
-**[Apache License 2.0](LICENSE).** You may use, modify, and distribute (including commercially), provided you keep the copyright notice and the attribution in [`NOTICE`](NOTICE.md) and follow the license terms. Provided without warranty of any kind.
-
-| Item | Detail |
-|------|--------|
-| License | [Apache License 2.0](LICENSE) |
-| Copyright | © 2026 SanHsien |
-| Contact | sanhsien@pm.me |
-| Fair use | Only for exporting the ebooks **you lawfully own**; no ACSM parsing, no key extraction, no protection removal |
-| Warranty | Provided "AS IS" with no warranty; all risk and legal responsibility rests with the user |
-| Notice | [`NOTICE.md`](NOTICE.md) |
-
----
-
-<div align="center">
-Only for exporting the ebooks you <b>lawfully own</b>. No ACSM parsing, no key extraction, no protection removal. Please respect copyright and each service's terms.
-</div>
+The software is provided **AS IS**, without warranty. Respect copyright, publisher restrictions, and service terms.

--- a/README.md
+++ b/README.md
@@ -1,108 +1,65 @@
 <div align="center">
 
-# 📚 OpenShelf
+# OpenShelf
 
-**枚舉並批次匯出你在 Google Play 圖書購買的電子書**
+**把你在 Google Play 圖書中可合法匯出的電子書，批次整理到自己的電腦。**
 
-無 DRM 書下載 EPUB / PDF · DRM 書下載官方 `.acsm` 供 Adobe Digital Editions 閱讀 · 無法匯出的只記錄
+無 DRM 書下載 EPUB / PDF · DRM 書保存官方 `.acsm` 交給 Adobe Digital Editions · 無法匯出的只記錄
 
 **繁體中文** ｜ [English](README.en.md)
 
+[![Release](https://img.shields.io/github/v/release/SanHsien/openshelf?sort=semver)](https://github.com/SanHsien/openshelf/releases/latest)
 [![CI](https://github.com/SanHsien/openshelf/actions/workflows/ci.yml/badge.svg)](https://github.com/SanHsien/openshelf/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![Playwright](https://img.shields.io/badge/Login-Playwright-2EAD33?logo=playwright&logoColor=white)](https://playwright.dev/python/)
-[![Download](https://img.shields.io/badge/Transport-HTTP%20(httpx)-blue)](https://www.python-httpx.org/)
-[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)]()
-[![Status](https://img.shields.io/badge/Status-穩定版%20v1.0.4-brightgreen)]()
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](#平台支援)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
+[下載最新版](https://github.com/SanHsien/openshelf/releases/latest) · [從原始碼執行](#從原始碼執行) · [開發與測試](#開發與測試)
 
 </div>
 
----
-
-> [!IMPORTANT]
-> **本工具只做合法匯出，不破解任何保護。**
-> `.acsm` 只是一張領取憑證，不含書的內容；真正下載書、綁定 Adobe ID、管理 DRM 的是 ADE，書全程保持加密。OpenShelf 對 `.acsm` 只做兩件事：**下載**、**原樣存檔**。
-> **不解析 ACSM、不在 ADE 之外 fulfill、不抽金鑰、不移除任何保護。** 要的若是「脫殼／解 DRM」，本工具不做。
-
-## ✨ 特色
-
-- 🔎 **一鍵枚舉**整個 Google Play 圖書庫，自動分類每本書的可匯出狀態。
-- 📥 **三態分流**：無 DRM 抓 EPUB/PDF、DRM 抓官方 `.acsm`、無法匯出的只留紀錄。
-- 🔐 **不碰你的帳密**：登入由你在真實瀏覽器手動完成一次，程式只沿用登入態。
-- 🌐 **HTTP-first**：枚舉與下載走 `httpx` 後端端點，不依賴脆弱的頁面 DOM。
-- 🧾 **manifest 為單一事實來源**：續傳、跳過已下載、產出統計報表。
-- ♻️ **可重複執行**：中斷後再跑會自動接續，不重抓。
-- 🖥️ **桌面介面**：搜尋、封面縮圖、下載佇列與預估剩餘時間、重試失敗、CSV/HTML 匯出、**中／英文介面**。
-
-## 🖼️ 畫面截圖
-
 ![OpenShelf 主畫面](docs/screenshots/main-window.png)
 
-> 截圖使用示範資料，不含真實 Google 帳號、書庫或下載內容。
+OpenShelf 是一個本機執行的 Google Play 圖書匯出工具。你只需在瀏覽器手動登入一次；之後程式會枚舉自己的書庫、判斷每本書可否匯出，並把結果整理成可續傳的 manifest。
 
-## 📑 目錄
+它的重點不是「破解電子書」，而是把 Google 本來就提供給你的官方匯出結果，從逐本操作改成可重複、可檢查、可批次執行的流程。
 
-- [重要邊界與聲明](#-重要邊界與聲明)
-- [畫面截圖](#️-畫面截圖)
-- [運作原理](#-運作原理)
-- [快速開始](#-快速開始)
-- [指令](#-指令)
-- [用 ADE 閱讀 `.acsm`](#-用-ade-閱讀-acsm)
-- [設定](#️-設定)
-- [輸出與 manifest](#-輸出與-manifest)
-- [專案結構](#️-專案結構)
-- [測試](#-測試)
-- [開發路線](#️-開發路線)
-- [常見問題](#-常見問題)
-- [打包成 .exe](#-打包成-exepyinstaller)
-- [限制與注意](#️-限制與注意)
-- [第三方工具背景](#-第三方工具背景)
-- [授權與版權](#-授權與版權)
+## 你可以做什麼
 
-## 🧱 重要邊界與聲明
-
-| 做 ✅ | 不做 ❌ |
+| 書籍狀態 | OpenShelf 的處理方式 |
 |---|---|
-| 自動下載你已購書的官方匯出檔 | 解析 `.acsm` 內容 |
-| 無 DRM 書存成 EPUB/PDF | 在 ADE 之外自行 fulfill、抽 EPUB |
-| DRM 書下載 `.acsm`，原樣存檔交給 ADE | 抽取 Adobe ADEPT 金鑰 |
-| 分類、記錄、跳過無法匯出的書 | 移除或破壞任何 DRM／保護措施 |
+| Google 提供 EPUB / PDF | 下載官方無 DRM 檔案 |
+| Google 只提供 ACSM | 下載官方 `.acsm`，原樣交給 Adobe Digital Editions |
+| Google 不提供任何匯出 | 記錄為 `no_export`，不嘗試繞過限制 |
+| 下載或端點失敗 | 記錄為 `failed`，之後可重試 |
 
-> 自動化操作已登入的 Google 服務可能牴觸其服務條款，請自行評估與承擔。本工具僅供你匯出**自己合法擁有**的書。
+其他重點：
 
-## 🧭 運作原理
+- **本機優先**：沒有 OpenShelf 雲端帳號，也不代管你的書庫或檔案。
+- **不碰帳密**：登入在真實瀏覽器由你自己完成，程式只沿用登入態。
+- **HTTP-first**：登入後的枚舉與下載走後端請求，不依賴容易改版的頁面按鈕與 DOM。
+- **可續跑**：`manifest.json` 記錄狀態；中斷後重新執行不必全部重抓。
+- **GUI + CLI**：一般使用者可用桌面介面；進階使用者可用 `openshelf` 指令。
+- **報表與交接**：可產生 TXT / CSV / HTML 報表，並將 EPUB/PDF、ACSM 分別交給適合的閱讀工具。
 
-採 **HTTP-first**：瀏覽器**只負責一次性登入**（Google 不允許腳本帶帳密登入，手動登入最穩），登入態存到本機後，**枚舉書庫與下載都改用 `httpx` 直接呼叫 Play Books 網頁版同款後端端點**，不依賴頁面 DOM／按鈕選擇器（DOM 最容易隨改版壞）。
+## 下載與使用
 
-```mermaid
-flowchart LR
-    A[openshelf login<br/>瀏覽器手動登入一次] -->|storage_state.json| B[openshelf scan<br/>HTTP 枚舉書庫]
-    B -->|manifest.json| C[openshelf export<br/>HTTP 逐本下載]
-    C --> D{分類}
-    D -->|drm_free| E[EPUB / PDF]
-    D -->|acsm| F[.acsm → 交給 ADE]
-    D -->|no_export| G[只記錄]
-    C --> H[openshelf status<br/>統計報表]
-```
+### Windows：直接下載正式版
 
-**分類規則**：
+前往 [Latest Release](https://github.com/SanHsien/openshelf/releases/latest)。目前正式版提供 Windows 安裝程式與可攜包；每個主要發行檔都附 SHA-256 校驗檔。
 
-| 書庫可匯出 | 分類 | 動作 |
-|---|---|---|
-| 有 EPUB / PDF | `drm_free` | 下載書檔，副檔名 + 檔案大小覆核 |
-| 只有 ACSM | `acsm` | 下載 `.acsm`，原樣存檔 |
-| 無任何匯出 | `no_export` | 只記錄 |
-| 流程出錯 | `failed` | 記錄錯誤，下次重試 |
+第一次啟動後，照畫面完成：
 
-下載後再以副檔名與檔案大小覆核：`.acsm` 只有幾 KB（XML），EPUB/PDF 明顯較大；不符就標 `failed` 待重試。
+1. **登入**：開啟瀏覽器並登入自己的 Google 帳號。
+2. **掃描**：讀取 Google Play 圖書庫並建立清單。
+3. **下載**：下載可匯出的 EPUB/PDF 或官方 `.acsm`。
+4. **查看結果**：搜尋、重試失敗項目，或匯出報表。
 
-> [!NOTE]
-> **端點隔離**：Play Books 沒有官方的「下載已購書」API。書庫枚舉走私有的 `SyncUserLibrary` gRPC-Web RPC（以 SAPISIDHASH 認證），下載 URL 一併內含於回應；無 DRM 書是直抓連結，DRM 書是 `.acsm` 領取憑證。這層全部隔離在 `openshelf/playbooks.py`，Google 後端改版時只需改這一個檔。
+> Windows 發行檔目前未做 Authenticode 程式碼簽章，SmartScreen 可能顯示未知發行者。請從本 repo 的 Release 下載並核對 SHA-256。
 
-## 🚀 快速開始
+### 從原始碼執行
 
-**需求**：Python 3.11+、可開圖形視窗的環境（首次登入用）。
+需求：Python 3.11+。
 
 ```bash
 git clone https://github.com/SanHsien/openshelf.git
@@ -110,314 +67,129 @@ cd openshelf
 pip install -e .
 ```
 
-> 首次登入會優先使用本機 Chrome / Edge。只有你要退回 Playwright 內建 Chromium，才需要另外執行 `playwright install chromium`。
+第一次使用：
 
 ```bash
-openshelf login     # 1) 開瀏覽器，手動登入一次
-openshelf scan      # 2) 枚舉書庫、建立 manifest
-openshelf export    # 3) 下載可匯出的書
-openshelf status    # 4) 看統計
+openshelf login
+openshelf scan
+openshelf export
+openshelf status
 ```
 
-## 🧩 指令
-
-| 指令 | 說明 | 常用選項 |
-|---|---|---|
-| `openshelf login` | 開瀏覽器手動登入一次，保存登入態 | `--headless` |
-| `openshelf scan` | 以 HTTP 枚舉書庫並分類，寫入 manifest | |
-| `openshelf export` | 以 HTTP 下載可匯出的書（EPUB/PDF 或 `.acsm`） | `--format pdf`、`--skip-acsm`、`--only`、`--limit`、`--refresh-acsm`、`--force-refresh-acsm`、`--skip-failed` |
-| `openshelf status` | 顯示 manifest 統計，並更新下載報表 | |
-| `openshelf report` | 在輸出目錄產生報表（缺漏清單／CSV／HTML） | `--format txt\|csv\|html\|all` |
-| `openshelf doctor` | 端點健康檢查：確認 Google 後端回應結構仍符合預期 | |
-| `openshelf acsm-open` | 批次用系統預設程式開啟已下載的 `.acsm` | `--dry-run`、`--limit`、`--include-opened` |
-| `openshelf acsm-report` | 產生 ACSM 交接報表，不開啟檔案 | |
-| `openshelf ebook-open` | 批次開啟已下載的無 DRM EPUB/PDF | `--target ade`、`--target default`、`--dry-run` |
-| `openshelf ebook-report` | 產生 EPUB/PDF 交接報表，不開啟檔案 | `--target ade`、`--target default` |
-| `openshelf calibre-import` | 把已下載的無 DRM EPUB/PDF 匯入 Calibre 書庫 | `--library-path`、`--dry-run` |
-| `openshelf calibre-report` | 產生 Calibre 交接報表，不執行匯入 | |
-| `openshelf ui` | 開啟桌面圖形介面（需 `pip install -e '.[gui]'`） | |
+若要桌面介面：
 
 ```bash
-openshelf export --format pdf            # 無 DRM 書偏好 PDF（無 PDF 時退回 EPUB）
-openshelf export --skip-acsm             # 只下載無 DRM 書，DRM 書僅記錄不抓 .acsm
-openshelf export --only acsm --limit 1   # 測試用：只抓 1 本 DRM 書的 .acsm
-openshelf export --force-refresh-acsm --limit 25  # ADE 顯示 E_ADEPT_REQUEST_EXPIRED 時，分批重抓 .acsm
-openshelf export --skip-failed           # 不再重試已知失敗（如 Google 端不給檔者）
-openshelf acsm-open --dry-run            # 檢查可交接 ADE / 系統預設程式的 .acsm
-openshelf acsm-open --limit 25           # 分批開啟已下載的 .acsm
-openshelf acsm-open --limit 25 --include-opened  # ADE 當場失敗時，重送先前已送出的一批
-openshelf ebook-open --target ade --dry-run  # 檢查可交接 ADE 的無 DRM EPUB/PDF
-openshelf ebook-open --target ade            # 批次用 ADE 開啟無 DRM EPUB/PDF
-openshelf calibre-import --dry-run       # 檢查可匯入 Calibre 的無 DRM 檔案
-openshelf calibre-import                 # 匯入已下載的無 DRM EPUB/PDF 到 Calibre
-openshelf --config path/to/config.toml status   # 指定設定檔
+pip install -e ".[gui]"
+openshelf ui
 ```
 
-> Calibre 交接只處理 manifest 中 `drm_free` 且檔案存在的 EPUB/PDF；`.acsm` 不會匯入 Calibre，仍需用 ADE 開啟。
+登入會優先使用本機 Chrome / Edge；只有需要 Playwright 內建 Chromium fallback 時才需另外安裝 Chromium。
 
-## 📖 用 ADE 閱讀 `.acsm`
+## 工作流程
 
-DRM 書下載到的是 `.acsm`，**不是書本身**。閱讀步驟（在你自己的電腦上完成，本工具不介入）：
-
-1. 安裝 **Adobe Digital Editions 4.5**，用你的 Adobe ID 授權這台電腦。
-2. 雙擊 `output/` 裡的 `.acsm`，或執行 `openshelf acsm-open` 批次交接給系統預設程式。
-3. 之後在 ADE 內閱讀。書受 Adobe DRM 保護，僅能在已授權的 ADE／裝置上開啟。
-
-若 ADE 顯示 `E_ADEPT_REQUEST_EXPIRED`，代表這批 `.acsm` 領取憑證已失效。請先在 OpenShelf 重新下載官方 `.acsm`：桌面版勾選 **強制重抓 .acsm** 後按「下載」，或 CLI 執行 `openshelf export --force-refresh-acsm`，再重新用 ADE 開啟。
-
-大量 `.acsm` 不建議一次全部丟進 ADE。ADE 會排隊處理，後面的憑證可能在排隊時失效。建議分批操作：
-
-1. 桌面版：把 **批次** 設為 20～30，勾 **強制重抓 .acsm** 後按「下載」，再按「開啟ACSM」。等 ADE 處理完本批後重複。
-2. CLI：執行 `openshelf export --force-refresh-acsm --limit 25`，接著執行 `openshelf acsm-open --limit 25`。等 ADE 處理完本批後重複。
-3. OpenShelf 只會記錄「已送出給 ADE / 系統預設程式」，無法知道 ADE 是否成功匯入。若 ADE 當場失敗，桌面版勾 **包含已送出** 或 CLI 加 `--include-opened` 重送。
-
-`.acsm` 重抓選項差異：
-
-| 選項 | CLI | 用途 |
-|---|---|---|
-| **重抓逾時 .acsm** | `openshelf export --refresh-acsm` | 只重抓 OpenShelf 依「下載時間 + `acsm_valid_days`」推估已逾期的 `.acsm`。適合平常整理舊檔。 |
-| **強制重抓 .acsm** | `openshelf export --force-refresh-acsm` | 不看有效天數，重抓已下載過、且尚未送出給 ADE 的 `.acsm`。ADE 顯示 `E_ADEPT_REQUEST_EXPIRED` 時用這個，建議搭配 `--limit 25` 分批。 |
-
-OpenShelf 不解析 `.acsm`，因此不知道 Adobe 憑證真正到期時間；`acsm_valid_days` 只是提醒用的時效代理。
-
-## ⚙️ 設定
-
-設定寫在專案根目錄的 `config.toml`；未列出的項目使用內建預設值。
-
-| 鍵 | 預設 | 說明 |
-|---|---|---|
-| `output_dir` | `"output"` | 電子書與 `.acsm` 存放目錄 |
-| `profile_dir` | `".profile"` | Playwright 持久化登入 profile（勿提交） |
-| `storage_state` | `"storage_state.json"` | 登入態快照（cookies，勿提交） |
-| `prefer_format` | `"epub"` | 無 DRM 書偏好格式，`epub` 或 `pdf` |
-| `include_acsm` | `true` | 是否抓 DRM 書的 `.acsm` |
-| `throttle_seconds` | `2.0` | 每本之間間隔秒數（節流） |
-| `download_timeout` | `120` | 單本下載逾時秒數 |
-| `download_retries` | `3` | 下載失敗重試次數（網路錯誤／5xx 才重試） |
-| `acsm_valid_days` | `7` | `.acsm` 視為有效的天數（以**下載時間**為準的時效代理） |
-| `calibredb_path` | `""` | Calibre CLI 路徑；留空時自動找 `calibredb` 與常見安裝位置 |
-| `calibre_library` | `""` | Calibre 書庫路徑；留空時使用 Calibre 預設書庫 |
-| `ade_path` | `""` | ADE 執行檔路徑；留空時找常見安裝位置，找不到則使用系統預設程式 |
-
-## 📂 輸出與 manifest
-
-- 電子書與 `.acsm` → `output/`（預設，可在 `config.toml` 調整）。
-- `output/manifest.json` → 每本書的 `volume_id`、書名、作者、出版社、分類（`drm_free` / `acsm` / `no_export` / `failed`）、下載路徑、時間。**續傳與跳過都依此判斷**（機器讀）。
-- `output/下載報表.txt` → **人看得懂的報表**，scan／export／status 後自動更新，重點列出**缺漏的書**（失敗、無法匯出）與逾時的 `.acsm`。也可隨時 `openshelf report` 重產。
-- `output/ACSM交接報表.txt` → 列出可用 ADE / 系統預設程式開啟的 `.acsm`，以及檔案遺失項目。
-- `output/EPUB-PDF交接報表.txt` → 列出可交接 ADE / 系統預設程式的無 DRM EPUB/PDF，以及檔案遺失項目。
-- `output/Calibre交接報表.txt` → 列出可匯入 Calibre 的無 DRM EPUB/PDF、檔案遺失項目，以及不匯入的 `.acsm`。
-
-> `output/`、`.profile/`、`storage_state.json` 皆已列入 `.gitignore`，不會進版控。
-
-## 🗂️ 專案結構
-
-```
-openshelf/
-  cli.py        指令進入點（login / scan / export / status / report / doctor / 交接 / ui）
-  config.py     讀取 config.toml + 預設值
-  browser.py    Playwright 一次性登入、保存 storage_state（cookies）
-  session.py    把 storage_state 載入成帶登入態的 httpx client
-  playbooks.py  Play Books 後端端點：枚舉書庫、取得匯出選項、解析下載 URL
-  classify.py   drm_free / acsm / no_export 判斷
-  export.py     HTTP 下載（EPUB/PDF 與 .acsm）、命名、覆核
-  manifest.py   讀寫 manifest（續傳、跳過、報表）
-  acsm.py       ACSM 交接（批次用系統預設程式開啟 .acsm）
-  reader.py     EPUB/PDF 交接（無 DRM 檔案可交給 ADE 或系統預設程式）
-  calibre.py    Calibre 交接（只匯入無 DRM EPUB/PDF）
-  service.py    scan / export 協調邏輯（CLI 與 GUI 共用）；報表 txt / csv / html
-  logsetup.py   結構化日誌（output/openshelf.log）
-  update.py     檢查 GitHub Releases 是否有新版（純比對，不自動覆寫）
-  ui/           桌面圖形介面（PySide6）；i18n.py 中英介面字串
-app.py          桌面應用進入點（供打包）
-assets/         應用圖示（openshelf.ico／.png；exe 與視窗 icon 共用）
-openshelf.spec  PyInstaller 打包設定（單檔、視窗模式、內嵌 icon）
-build_exe.py    在本機建置執行檔的便捷腳本
-tools/          維護工具（README 假資料截圖、依賴新鮮度檢查、Dependabot 更新分類）
-tests/          單元／整合測試（解析、分類、命名、manifest、設定、報表、ACSM 時效、i18n、依賴自動化）
-installer/      Inno Setup 安裝程式腳本（openshelf.iss）
-docs/           截圖流程、第三方工具背景、各版 release notes
-.github/        CI、Release、Dependabot 與依賴新鮮度 workflows；issue／PR 範本
-config.toml     設定檔
-pyproject.toml  套件與相依
+```mermaid
+flowchart LR
+    A[手動瀏覽器登入] --> B[scan 書庫]
+    B --> C[manifest.json]
+    C --> D[export]
+    D --> E[EPUB / PDF]
+    D --> F[官方 .acsm]
+    D --> G[no_export / failed 紀錄]
+    C --> H[status / report]
 ```
 
-## 🧪 測試
+Google Play Books 沒有公開的「下載已購書」API。OpenShelf 將目前使用的書庫端點集中隔離在 `openshelf/playbooks.py`；如果 Google 改版，主要需要維護的是這一層，而不是整個 GUI。
 
-不需網路、不需瀏覽器、不需登入態。涵蓋解析書庫回應、三態分類、檔名去重與覆核、manifest、設定、報表、ACSM 時效、中英介面字串，以及以 mock `httpx` 驅動的分頁／分類整合測試與依賴維護工具：
+## 常用指令
+
+| 指令 | 用途 |
+|---|---|
+| `openshelf login` | 手動登入並保存登入態 |
+| `openshelf scan` | 枚舉書庫並更新 manifest |
+| `openshelf export` | 下載可匯出的 EPUB/PDF 或 `.acsm` |
+| `openshelf status` | 查看目前統計與狀態 |
+| `openshelf report` | 產生 TXT / CSV / HTML 報表 |
+| `openshelf doctor` | 檢查 Google 後端端點是否仍符合預期 |
+| `openshelf acsm-open` | 將已下載的 `.acsm` 交給系統預設程式 / ADE |
+| `openshelf ebook-open` | 開啟已下載的無 DRM EPUB/PDF |
+| `openshelf calibre-import` | 將無 DRM EPUB/PDF 匯入 Calibre |
+| `openshelf ui` | 開啟桌面介面 |
+
+查看完整參數：
+
+```bash
+openshelf --help
+openshelf export --help
+```
+
+幾個常見例子：
+
+```bash
+openshelf export --format pdf
+openshelf export --skip-acsm
+openshelf export --only acsm --limit 10
+openshelf export --force-refresh-acsm
+openshelf calibre-import --dry-run
+```
+
+## `.acsm` 與 DRM 邊界
+
+> [!IMPORTANT]
+> **OpenShelf 不破解 DRM。**
+
+`.acsm` 是 Adobe Digital Editions 使用的領取憑證，不是電子書內容本身。OpenShelf 對 `.acsm` 只做兩件事：**下載**、**原樣保存／交接**。
+
+OpenShelf **不會**：
+
+- 解析 ACSM 內容以自行 fulfill；
+- 抽取 Adobe ADEPT 或其他金鑰；
+- 解密、脫殼或移除 DRM；
+- 嘗試取得 Google 沒有提供匯出權限的書檔。
+
+如果 ADE 顯示 `E_ADEPT_REQUEST_EXPIRED`，可重新下載官方 `.acsm`：
+
+```bash
+openshelf export --force-refresh-acsm
+```
+
+背景與第三方工具邊界見 [`docs/third-party-ebook-tooling.md`](docs/third-party-ebook-tooling.md)。
+
+## 平台支援
+
+| 平台 | 狀態 |
+|---|---|
+| Windows 10/11 x64 | **主要驗證平台**；提供安裝程式與可攜 Release |
+| macOS | CI 會建置 `.app`，目前未宣稱完整實機驗收 |
+| Linux x64 | CI 會建置執行檔，需桌面環境完成登入；目前未宣稱完整實機驗收 |
+
+跨平台核心為 Python；GUI 使用 PySide6，登入使用瀏覽器 / Playwright，下載使用 `httpx`。
+
+## 資料與隱私
+
+OpenShelf 沒有後端服務。登入態、manifest、下載檔與 log 都保存在你的電腦上。
+
+請注意：自動化操作已登入的 Google 服務可能受 Google 服務條款約束；本工具僅設計用於匯出**你自己合法擁有、且服務本身允許匯出**的電子書。
+
+## 開發與測試
+
+安裝開發環境後：
 
 ```bash
 python -m unittest discover -s tests
 ```
 
-README 主畫面截圖以固定假資料產生，不使用真實書庫：
+CI 會在 GitHub Actions 執行測試；Release workflow 負責各平台建置與發行。版本資訊以 `pyproject.toml` 與 Release tag 為準。
 
-```bash
-python tools/generate_readme_screenshot.py
-```
+維護相關文件：
 
-流程細節見 [docs/screenshot-workflow.md](docs/screenshot-workflow.md)。
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — 貢獻與開發流程
+- [`REPO_REVIEW.md`](REPO_REVIEW.md) — 專案檢視與後續改善紀錄
+- [`docs/release-notes/`](docs/release-notes/) — 各版本發行說明
+- [`docs/screenshot-workflow.md`](docs/screenshot-workflow.md) — README 截圖產生流程
+- [`NOTICE.md`](NOTICE.md) — 第三方歸屬與聲明
 
-## 🛣️ 開發路線
+## 授權
 
-### ✅ 已完成（M1–M11，目前 v1.0.4）
+[Apache License 2.0](LICENSE)。Copyright © 2026 SanHsien。
 
-- [x] **M1**：瀏覽器一次性登入 + 保存登入態（`browser.py` / `session.py`）
-- [x] **M2**：端點探勘——SyncUserLibrary RPC + SAPISIDHASH 認證，填入 `playbooks.py`
-- [x] **M3**：三態分類 + `scan` 寫入 manifest
-- [x] **M4**：HTTP 下載（EPUB/PDF 直抓、`.acsm` 原樣存檔）+ 檔名 + 覆核 + 續傳 + `status`
-- [x] **M5**：節流、下載重試＋退避、認證過期友善提示、同名書檔名去重、檔頭覆核、單元測試
-- [x] **M6**：桌面 UI 殼（PySide6）：書單表格、掃描／下載／停止、log、狀態列（背景執行緒 + 訊號）
-- [x] **M7**：PyInstaller 打包單一執行檔（`app.py` / `openshelf.spec` / `build_exe.py`；frozen 路徑與 Chromium 攜帶已處理）
-- [x] **M8**：交接與公開整備——`.acsm` / EPUB·PDF / Calibre 三種交接與報表、人可讀下載報表、`.acsm` 時效提醒、書庫自動分頁、應用圖示與「關於」、Apache-2.0 授權、GitHub Actions CI 與貢獻範本
-- [x] **M9**：桌面體驗（v0.4）——表格搜尋與記住欄寬、封面縮圖、下載佇列與預計剩餘時間、重試失敗、CSV/HTML 報表、中英介面（i18n）與雙語 README
-- [x] **M10**：打包與發佈（v0.5）——CI 自動建置 Windows exe 並發佈 Release（精簡／可攜／安裝程式三種包 + SHA256）、自動更新檢查、首次啟動導覽、程式碼簽章說明
-- [x] **M11**：穩定版（v1.0）——端點自我診斷（`openshelf doctor`）、mock httpx 整合測試（分頁／分類）、結構化日誌（`output/openshelf.log`）、跨平台 CI 建置（macOS `.app`／Linux 執行檔；非 Windows 版本尚未實機測試）
-
-> 目前進度：**穩定版（v1.0.4）**——`login → scan → export` 全線打通；三態分流、下載重試、三種交接與報表、桌面 GUI（搜尋／封面／佇列／中英介面／導覽／檢查更新）、ACSM 分批交接、端點自我診斷與結構化日誌、Windows/macOS/Linux CI 自動發佈。Windows Release 產物已本機啟動／安裝測試；macOS/Linux 產物目前僅由 CI 建置，尚未在對應系統實機測試。測試涵蓋 parser、分類、報表、ACSM 時效、i18n 與依賴維護工具，實際項數以 CI 結果為準。
-
-### 🗺️ 發展路線圖（規劃中）
-
-> 以下皆在專案邊界內推進；**永遠不會**加入 DRM 規避／解密／脫殼、ACSM 解析、ADE 外 fulfill、金鑰抽取（見下方「永不做」）。
-
-```mermaid
-timeline
-    title OpenShelf 路線圖
-    v0.4 桌面體驗 : 搜尋與多欄排序 : 封面縮圖 : 下載佇列與進度細節 : 英文介面 (i18n)
-    v0.5 打包與發佈 : GitHub Actions 自動建置 Windows exe : 一鍵附帶 Chromium 的可攜包 : 安裝程式與捷徑/icon : 自動更新檢查
-    v1.0 穩定版 : 端點自我診斷 : 整合測試 (mock httpx) : 結構化日誌 : 跨平台打包 (macOS/Linux 未實機測試)
-```
-
-**v0.4 — 桌面體驗** ✅ 已完成
-- [x] 表格搜尋框與排序、記住欄寬
-- [x] 書籍封面縮圖（來自書庫 metadata，不另抓內容）
-- [x] 下載佇列視覺化：目前書名、預計剩餘時間、失敗即時重試鈕
-- [x] 報表可匯出 CSV／HTML
-- [x] 介面英文化（i18n），README 雙語
-
-**v0.5 — 打包與發佈（exe 強化重點）** ✅ 已完成
-- [x] **CI 自動建置 Windows `.exe`** 並發佈到 GitHub Releases（tag 觸發、附 SHA256）
-- [x] **可攜整合包**：一鍵把 `ms-playwright/` Chromium 附進 `dist/`，使用者解壓即用、免再 `playwright install`
-- [x] **安裝程式**（Inno Setup）：開始功能表捷徑、桌面 icon、解除安裝
-- [x] **自動更新檢查**：比對 GitHub Releases 最新版，提示下載（不自動覆寫）
-- [x] 程式碼簽章說明，降低 Windows SmartScreen 警告
-- [x] 首次啟動精靈：引導 登入 → 掃描 → 下載
-
-**v1.0 — 穩定版** ✅ 已完成
-- [x] 端點健康檢查／自我診斷（`openshelf doctor`）：Google 後端改版時主動提示，集中於 `playbooks.py`
-- [x] 整合測試（mock `httpx` 回應），涵蓋分頁、去重、停止條件與各分類
-- [x] 結構化日誌與輸出到檔（`output/openshelf.log`），方便回報問題
-- [x] 跨平台打包：CI 於 macOS 產出 `OpenShelf.app`、Linux 產出執行檔（`.dmg`／AppImage 之精緻封裝為後續選配）；非 Windows 版本尚未實機測試
-
-### 🚫 永遠不會做（邊界）
-
-- DRM 規避、解密、脫殼。
-- 解析 `.acsm` 內容、在 ADE 之外 fulfill、抽取 Adobe ADEPT／金鑰。
-- 移除或破壞任何電子書的保護措施，或整合這類第三方工具。
-
-> 任何 issue／PR 若往上述方向走，會被婉拒。背景見 [`docs/third-party-ebook-tooling.md`](docs/third-party-ebook-tooling.md)。
-
-## ❓ 常見問題
-
-<details>
-<summary><b>為什麼登入還要開瀏覽器？不能直接打 API 嗎？</b></summary>
-
-Google 對「腳本帶帳密登入」有強力封鎖（CAPTCHA、二階段驗證、安全阻擋），硬刻又脆弱又可能害帳號被風控。讓你在真實瀏覽器手動登入一次、之後沿用登入態，是最穩也最安全的做法。程式全程不經手帳密。
-</details>
-
-<details>
-<summary><b>OpenShelf 會幫我解開 DRM 嗎？</b></summary>
-
-不會，也不該。DRM 書只會下載官方 `.acsm` 供 ADE 閱讀，書全程保持加密。本工具不解析 ACSM、不抽金鑰、不移除保護。
-</details>
-
-<details>
-<summary><b>為什麼有些書被歸為 <code>no_export</code>？</b></summary>
-
-並非每本書、每個地區都提供匯出。不少書只能留在 Play Books App 內閱讀，這類沒有任何可下載的檔案，會被記錄為 `no_export`。
-</details>
-
-<details>
-<summary><b><code>.acsm</code> 下載後一直沒用 ADE 開，會怎樣？</b></summary>
-
-`.acsm` 通常有領取時效／裝置授權限制，需及時用 ADE fulfill；逾時或換機可能失效。這由 Adobe／出版商決定，非本工具可控。
-
-若 ADE 顯示 `E_ADEPT_REQUEST_EXPIRED`，代表憑證已失效。請重抓官方 `.acsm`：桌面版勾選 **強制重抓 .acsm** 後按「下載」，或 CLI 執行 `openshelf export --force-refresh-acsm`。
-</details>
-
-<details>
-<summary><b>Google 改版會不會壞掉？</b></summary>
-
-可能會。所有依賴 Google 未公開介面的工具都一樣。OpenShelf 把易變的端點集中在 `playbooks.py`，改版時通常只需改這一個檔。
-</details>
-
-## 📦 打包成 .exe（PyInstaller）
-
-> [!TIP]
-> **自動發佈（推薦）**：推一個 `v*` 版本標籤（如 `git tag v1.0.4 && git push origin v1.0.4`），GitHub Actions 會在 Windows 上自動建置並發佈到 **Releases**，附三種包：
-> - **精簡版** `OpenShelf-<版本>-windows-x64.zip`（只含 exe；登入用本機 Chrome/Edge）
-> - **可攜版** `OpenShelf-<版本>-windows-x64-portable.zip`（exe + 內建 Chromium，解壓即用）
-> - **安裝程式** `OpenShelf-<版本>-setup.exe`（開始功能表捷徑、可選桌面捷徑、可解除安裝）
->
-> 皆附 `.sha256` 校驗檔。流程見 [`.github/workflows/release.yml`](.github/workflows/release.yml)、安裝腳本見 [`installer/openshelf.iss`](installer/openshelf.iss)。
->
-> **Release notes**：打 tag 前先把該版說明寫進 `docs/release-notes/<tag>.md`（例：`docs/release-notes/v1.0.4.md`），workflow 會優先採用這份人工版本；沒有這個檔才退回 `--generate-notes`。發版前請一併確認 `pyproject.toml` 與 `openshelf/__init__.py` 的版本號和 tag 一致。
-
-> [!NOTE]
-> **關於 Windows SmartScreen**：未經程式碼簽章的 exe 首次執行可能被 SmartScreen 攔下（按「更多資訊 → 仍要執行」即可）。要消除警告需自備**程式碼簽章憑證**（OV/EV code signing），在打包後對 `OpenShelf.exe` 與安裝程式 `signtool sign /fd SHA256 /tr <時間戳伺服器> /td SHA256 ...`。本專案不內含憑證；如需，於 CI 以 secret 注入憑證再加一個簽章步驟。
-
-> [!IMPORTANT]
-> PyInstaller **不是跨平台編譯器**：要產出 Windows `.exe`，必須**在 Windows 上**執行打包；在 macOS／Linux 上打包只會得到該平台的執行檔。目前除 Windows 外之 CI 編譯產物均尚未實機測試。
-
-手動在目標作業系統（要 `.exe` 就用 Windows）上：
-
-```bash
-pip install -e ".[gui,build]"
-python build_exe.py              # 等同 pyinstaller openshelf.spec --noconfirm
-```
-
-產物在 `dist/`（單檔、視窗模式，無主控台）。執行檔旁會自動建立 `output/`、`.profile/`、`storage_state.json`（打包後這些都落在 exe 同目錄，不寫進系統目錄）。
-
-### Chromium 怎麼帶（重要）
-
-登入會優先使用本機 Chrome / Edge；只有退回 Playwright 內建 Chromium 時才需要 Chromium 瀏覽器檔。Chromium **不會被打進 exe**（瀏覽器二進位龐大且獨立於 pip 套件）。`app.py` 已將 `PLAYWRIGHT_BROWSERS_PATH` 指向 **exe 旁的 `ms-playwright/`**，若你需要內建 Chromium fallback，請二擇一：
-
-1. **隨 exe 攜帶（推薦給散布）**：打包前先 `playwright install chromium`，把本機 Playwright 瀏覽器快取中的 `chromium-*` 資料夾複製到 `dist/ms-playwright/`，與 exe 一起散布。
-2. **使用者端首次安裝**：在使用者機器上跑一次 `playwright install chromium`，並把瀏覽器放到 exe 旁的 `ms-playwright/`（或設定相同的 `PLAYWRIGHT_BROWSERS_PATH` 環境變數）。
-
-> 下載（`httpx`）與枚舉不需瀏覽器；Chromium 只在 `登入` 時用到。
-
-## ⚠️ 限制與注意
-
-- DRM 書只下載官方 `.acsm` 供 ADE 閱讀；**不解析 ACSM、不抽金鑰、不移除保護**。
-- **`.acsm` 時效**：`.acsm` 有領取時效／裝置授權限制，建議**分批下載、隨即用 ADE 開**。本工具以「**我們下載該 `.acsm` 的時間** + `acsm_valid_days`」當時效代理：逾期會在 `status` 標示並可 `openshelf export --refresh-acsm` 重抓。
-  > ⚠️ 本工具**不讀取 `.acsm` 內含的真正到期時間**（那需要解析 ACSM 內容，違反本專案邊界）；上述時效僅為以下載時間估算的提醒，非 Adobe 憑證的實際到期。
-- **同名書辨識**：同書名（書名+作者）多本時，檔名以「出版年 · 出版社」區別；仍相同才補 `volume_id`，避免互相覆蓋。
-- **書庫分頁**：枚舉會自動分頁直到取齊（依回應的總數與游標）；單頁上限 400 本。
-- 並非每本書、每個地區都提供匯出，無法匯出者歸為 `no_export`。
-- 自動化操作已登入的 Google 服務可能牴觸其服務條款，請自行評估。
-- Google 書庫後端改版時，`playbooks.py` 的端點需更新。
-
-## 🧰 第三方工具背景
-
-關於 ADE、Calibre、Epubor 類工具與 OpenShelf 邊界，整理在
-[`docs/third-party-ebook-tooling.md`](docs/third-party-ebook-tooling.md)。
-
-## 📝 授權與版權
-
-**[Apache License 2.0](LICENSE)。** 你可以自由使用、修改與散布（含商用），惟須保留著作權聲明與 [`NOTICE`](NOTICE.md) 中的歸屬聲明，並依授權條款行事；本軟體不附帶任何擔保。
-
-| 項目 | 內容 |
-|------|------|
-| 授權 | [Apache License 2.0](LICENSE) |
-| 著作權 | Copyright © 2026 SanHsien |
-| 聯絡信箱 | sanhsien@pm.me |
-| 合理使用 | 僅供匯出**你自己合法擁有**之電子書；不解析 ACSM、不抽金鑰、不移除任何保護 |
-| 擔保 | 按「現狀」（AS IS）提供，不提供任何擔保；使用風險與法律責任由使用者自行承擔 |
-| 聲明 | [`NOTICE.md`](NOTICE.md) |
-
----
-
-<div align="center">
-僅供匯出你<b>自己合法擁有</b>的電子書。不解析 ACSM、不抽金鑰、不移除任何保護。請尊重著作權與各服務的使用條款。
-</div>
+本軟體按「現狀」提供，不附帶任何擔保。請尊重著作權、出版商限制與各服務條款。


### PR DESCRIPTION
## Summary
- turn both README files into product-focused landing pages instead of long project-history documents
- move download, screenshot, core value, and first-run workflow above implementation detail
- keep the DRM/ACSM boundary explicit without repeating it throughout the page
- keep Windows as the primary validated platform and distinguish CI-built macOS/Linux artifacts from real-device validation
- replace the M1–M11 history/roadmap wall with concise maintenance links and current commands

## Why
OpenShelf is already a stable, differentiated project, but the public entry point was carrying too much roadmap, packaging, and implementation history. This PR makes the repository easier to understand in the first minute without changing product behavior.

## Scope
Documentation-only: `README.md` and `README.en.md`.

## Verification
- release links are version-independent (`releases/latest`)
- documented commands match the existing CLI surface
- legal/DRM boundaries remain explicit
- no runtime code, dependencies, packaging, or workflows are changed