### PR TITLE
chore(deps): click 下限維持 >=8.4.2，改記 freshness-hold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "SanHsien", email = "sanhsien@pm.me" }]
 dependencies = [
     "playwright>=1.62.0",
     "httpx>=0.28.1",
-    "click>=8.5.0",
+    "click>=8.4.2",  # freshness-hold: 8.4.2 是我們實際承諾的相容下限。openshelf.cli 只用 click 的公開穩定 API（group/option/Choice/pass_context/ClickException），沒有任何一處需要 8.5 才有的行為；把下限跟著 PyPI 往上抬，只會讓受控或離線環境（只提供 8.4.2）安裝失敗，換到的僅是報告不再亮紅燈。
     "rich>=15.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "SanHsien", email = "sanhsien@pm.me" }]
 dependencies = [
     "playwright>=1.62.0",
     "httpx>=0.28.1",
-    "click>=8.4.2",
+    "click>=8.5.0",
     "rich>=15.0.0",
 ]
 


### PR DESCRIPTION
## 變更

依賴新鮮度檢查（[#1](https://github.com/SanHsien/openshelf/issues/1)）唯一一筆紅燈是 `click`：宣告 `>=8.4.2`，PyPI 現行版 8.5.0。

**這支 PR 一開始是把下限抬到 `>=8.5.0`——那是錯的做法**，Codex review 指出後已改正。本 repo `AGENTS.md` 寫得很清楚：宣告是相容性承諾，不是消音鍵；紅燈只有兩條正當出口（`# freshness-hold:` 或 dated deferral），調高下限不是其中之一。

現在的做法：下限**維持** `>=8.4.2`，在宣告那一行加 `# freshness-hold:`。

## 為什麼是 hold 不是 deferral

`openshelf.cli` 只用 click 的公開穩定 API（`group`／`option`／`Choice`／`is_flag`／`pass_context`／`Context`／`ClickException`），沒有任何一處需要 8.5 才有的行為。測試在 8.5.0 上通過只證明「8.5 可以用」，不證明「需要 8.5」。抬高下限會讓只提供 8.4.2 的受控／離線環境被迫升級或裝不起來，換到的僅是報告不再亮紅燈。

這是**長期政策**（執行期下限不跟著 PyPI 走），不是一次性延後——deferral 會在 PyPI 再往前時自動失效重問，不符合這裡的意圖，所以選 hold。

## 驗證

- [x] `tools/check_dependency_freshness.py` 重跑：`click` 標為 `HELD` 並附理由，不再是紅燈
- [x] 實裝 click 8.5.0：`python -m unittest discover -s tests` → **134 tests OK**（hold 約束的是宣告，不是能裝什麼）

## 待辦

`openshelf-personal` 的 `95c4ea8` 是同一個錯誤做法且已在 main，會另開 PR 用同樣方式改正。
